### PR TITLE
feat: add inactive account detection, filtering, and added status badges

### DIFF
--- a/src/services/service.js
+++ b/src/services/service.js
@@ -74,10 +74,27 @@ const getFollowers = async ({ userName, token }) => {
     return followers;
 };
 
+// Fetches the date of the latest public event for a user
+const getLatestPublicEventDate = async ({ userName, token }) => {
+    const headers = {};
+    if (token) {
+        headers.Authorization = `token ${token}`;
+    }
+    // Fetch the user's public events (most recent first)
+    const res = await fetch(`https://api.github.com/users/${userName}/events/public?per_page=1`, { headers });
+    if (!res.ok) return null;
+    const data = await res.json();
+    if (Array.isArray(data) && data.length > 0 && data[0].created_at) {
+        return data[0].created_at;
+    }
+    return null; // No public events found
+}
+
 
 export {
     getUserProfileInfo,
     getRateLimit,
     getFollowing,
     getFollowers,
+    getLatestPublicEventDate,
 }


### PR DESCRIPTION
Hi there,
I really like your project,it's a super useful tool for managing GitHub relationships, and the interface is very clean. I wanted to contribute something I thought would be helpful for users: the ability to detect and filter inactive accounts.
Summary of changes:
Detects inactive accounts by checking each user’s latest public activity.
Adds a filter toggle to show only inactive users.
Displays “Active” and “Inactive” status as compact, color-coded badges.
Improves the spacing and appearance of the status indicators.
I hope you find this feature useful. Let me know if you have any feedback or would like any changes!